### PR TITLE
fix(backend): resolve multi-agent execution bugs (#197, #198)

### DIFF
--- a/backend/claude_interface.py
+++ b/backend/claude_interface.py
@@ -5,7 +5,7 @@ This module provides async functions to spawn and interact with the Claude Code 
 as a subprocess, streaming output in real-time and handling errors gracefully.
 
 Key features:
-- Spawns Claude CLI with --yes flag for non-interactive mode
+- Spawns Claude CLI with --dangerously-skip-permissions flag for non-interactive mode
 - Sets working directory to ai-workspace
 - Streams stdout/stderr line-by-line
 - Captures exit codes
@@ -61,10 +61,10 @@ async def execute_claude_task(
         logger.info(f"Starting Claude task: {task_description[:100]}...")
         logger.debug(f"Working directory: {workspace_path}")
 
-        # Spawn subprocess with claude --yes command and task as argument
+        # Spawn subprocess with claude --dangerously-skip-permissions command and task as argument
         process = await asyncio.create_subprocess_exec(
             'claude',
-            '--yes',
+            '--dangerously-skip-permissions',
             task_description,  # Pass task as positional argument
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,

--- a/backend/executor.py
+++ b/backend/executor.py
@@ -139,8 +139,7 @@ async def _execute_multi_agent(
                 title=f"Task {'Completed' if exit_code == 0 else 'Failed'}: {task.name}",
                 message=f"Multi-agent execution {'completed' if exit_code == 0 else 'failed'}\nAgents: {len(result.get('completed_agents', []))}",
                 priority="default" if exit_code == 0 else "high",
-                tags=["task", "multi-agent", "completion" if exit_code == 0 else "error"],
-                db_session=db
+                tags=f"task,multi-agent,{'completion' if exit_code == 0 else 'error'}"
             )
 
         return output, exit_code
@@ -193,8 +192,7 @@ async def _execute_multi_agent(
                 title=f"Task Failed: {task.name}",
                 message=f"Multi-agent error: {str(e)}",
                 priority="urgent",
-                tags=["task", "multi-agent", "error"],
-                db_session=db
+                tags="task,multi-agent,error"
             )
 
         raise
@@ -371,8 +369,7 @@ Please execute this task and provide the output.
                 title=f"Task {'Completed' if exit_code == 0 else 'Failed'}: {task.name}",
                 message=f"Duration: {execution.duration}ms\nExit code: {exit_code}",
                 priority="default" if exit_code == 0 else "high",
-                tags=["task", "completion" if exit_code == 0 else "error"],
-                db_session=db
+                tags=f"task,{'completion' if exit_code == 0 else 'error'}"
             )
 
         # Send email notification if configured
@@ -431,8 +428,7 @@ Please execute this task and provide the output.
                 title=f"Task Timeout: {task.name}",
                 message=f"Task exceeded 1 hour timeout",
                 priority="urgent",
-                tags=["task", "timeout", "error"],
-                db_session=db
+                tags="task,timeout,error"
             )
 
         # Send email notification if configured
@@ -495,8 +491,7 @@ Please execute this task and provide the output.
                 title=f"Task Failed: {task.name}",
                 message=f"Error: {str(e)}",
                 priority="urgent",
-                tags=["task", "error"],
-                db_session=db
+                tags="task,error"
             )
 
         # Send email notification if configured


### PR DESCRIPTION
# Fix: Resolve Multi-Agent Execution Bugs (#197, #198)

This PR fixes two critical bugs that completely blocked multi-agent orchestration functionality and a bonus type mismatch bug that would have caused notification failures.

## Summary of Changes

### ✅ Issue #197: Invalid `--yes` Flag Blocks Multi-Agent Execution (CRITICAL)
- **Root Cause**: `backend/claude_interface.py` was using an invalid `--yes` flag when spawning Claude Code subprocesses
- **Impact**: Every agent subprocess failed immediately with exit code 1 (~313ms after spawn)
- **Fix**: Replaced `--yes` with `--dangerously-skip-permissions` (the correct flag for unattended execution)
- **Files Changed**: `backend/claude_interface.py` (lines 8, 64, 67)
- **Result**: Multi-agent orchestration now functional

### ✅ Issue #198: `send_notification()` Signature Mismatch (MEDIUM)
- **Root Cause**: Error handlers in `executor.py` were passing `db_session` argument to `send_notification()`, which doesn't accept it
- **Impact**: When tasks failed, notification sending crashed with `TypeError: got an unexpected keyword argument 'db_session'`
- **Secondary Impact**: Original error messages were masked by notification errors
- **Fix**: Removed `db_session` argument from all 5 `send_notification()` calls in `executor.py`
- **Files Changed**: `backend/executor.py` (lines 143, 197, 375, 435, 499)
- **Result**: Error notifications now send successfully without crashing

### ✅ Bonus Fix: Tags Parameter Type Mismatch
- **Root Cause**: All `send_notification()` calls were passing `tags` as a list (e.g., `["task", "error"]`) but the function signature expects a comma-separated string (e.g., `"task,error"`)
- **Impact**: Would have caused type errors when notification code attempted to use tags
- **Fix**: Converted all 5 tags arguments from list format to string format
- **Files Changed**: `backend/executor.py` (same 5 locations as Issue #198)
- **Result**: Tags now properly formatted for ntfy.sh API

## Test Results

**Backend Syntax Check:**
- ✅ `python3 -m py_compile backend/claude_interface.py` - No errors
- ✅ `python3 -m py_compile backend/executor.py` - No errors

**Frontend Build:**
- ✅ `npm run build` - Successful (no errors, 15/15 pages built)

**Frontend Lint:**
- ✅ `npm run lint` - No errors

**Manual Testing:**
- ✅ Multi-agent task can now spawn Claude Code subprocesses successfully
- ✅ No more immediate exit code 1 failures
- ✅ Error notifications work without crashing
- ✅ Tags format accepted by ntfy.sh API

## How to Test This PR

### 1. Setup

```bash
# Clone and checkout
git fetch origin
git checkout fix/issues-197-198-multi-agent-bugs

# No new dependencies to install
```

### 2. Run Build Verification

```bash
# Verify frontend builds successfully
npm run build

# Expected: ✓ Build completed successfully

# Verify lint passes
npm run lint

# Expected: No errors

# Verify Python syntax
cd backend
python3 -m py_compile claude_interface.py executor.py

# Expected: No output (success)
```

### 3. Manual Testing - Multi-Agent Execution

**Test Issue #197 Fix: Claude Code Subprocess Spawning**

1. **Start the backend service:**
   ```bash
   cd /Users/zhuge/dev/ai-assistant-prototype
   npm run dev:backend
   ```

2. **Trigger a multi-agent task:**

   Use an existing multi-agent test task from the database, or create one via API:

   ```bash
   # Get existing test task ID
   curl http://localhost:8000/api/tasks | jq '.[] | select(.name | contains("Multi-Agent")) | .id'

   # Or use the known test task ID
   TASK_ID="task_4b6abe9c69bf37da"

   # Trigger execution
   curl -X POST "http://localhost:8000/api/tasks/${TASK_ID}/execute"
   ```

3. **Verify subprocess spawns successfully:**

   Check the logs for successful agent execution:

   ```bash
   tail -f ai-workspace/logs/ai_assistant.log | grep -E "Claude subprocess|exit code|Agent.*completed"
   ```

   **Expected output (SUCCESS):**
   ```json
   {"message": "Starting Claude task: # Research Agent Instructions..."}
   {"message": "Claude subprocess spawned (PID: 12345)"}
   {"message": "Claude task completed with exit code: 0"}  // ✅ Exit code 0, not 1!
   {"message": "Agent 'research' completed successfully"}
   ```

   **Previous broken behavior (FAILURE):**
   ```json
   {"message": "Claude subprocess spawned (PID: 67952)"}
   {"message": "Claude task completed with exit code: 1"}  // ❌ Immediate failure
   {"message": "Agent 'research' failed: Agent exited with code 1"}
   ```

4. **Verify agent output files created:**

   ```bash
   # List the latest execution workspace
   ls -lh ai-workspace/tasks/*/agents/research/
   ```

   **Expected files:**
   - `output.json` - Agent's structured findings
   - `output.md` - Narrative summary (optional)
   - `status.json` - Status: "completed"
   - `instructions.md` - Agent's instructions

   **Before fix:** These files would never be created (subprocess crashed immediately)

**Test Issue #198 Fix: Error Notification Handling**

1. **Force a task to fail** (to trigger error notification):

   Create a task that will fail for a different reason:

   ```bash
   curl -X POST http://localhost:8000/api/tasks \
     -H "Content-Type: application/json" \
     -d '{
       "name": "Test Error Notification",
       "description": "Task designed to fail to test error handling",
       "command": "claude",
       "schedule": null,
       "metadata": {
         "agents": {
           "enabled": true,
           "sequence": ["research"],
           "synthesize": false,
           "roles": {
             "research": {
               "type": "research",
               "instructions": "This is a test - please exit with error code 1"
             }
           }
         }
       }
     }'
   ```

2. **Trigger the task:**

   ```bash
   # Get the task ID from the response above
   TASK_ID="<task_id_from_above>"

   # Execute it
   curl -X POST "http://localhost:8000/api/tasks/${TASK_ID}/execute"
   ```

3. **Verify error notification works:**

   Check the logs:

   ```bash
   tail -f ai-workspace/logs/ai_assistant.log | grep -E "notification|send_notification"
   ```

   **Expected (SUCCESS):**
   ```json
   {"message": "Sending notification: Task Failed: Test Error Notification"}
   {"message": "Notification sent successfully"}
   ```

   **Previous broken behavior (FAILURE):**
   ```json
   {"message": "Error sending notification: send_notification() got an unexpected keyword argument 'db_session'"}
   ```

4. **Verify notification received** (if ntfy.sh configured):

   - Check your ntfy.sh mobile app or web interface
   - Expected: Notification with title "Task Failed: Test Error Notification"
   - Priority: urgent
   - Tags: task,multi-agent,error (comma-separated string)

### 4. Expected Results

- ✅ Claude Code subprocess spawns successfully with `--dangerously-skip-permissions` flag
- ✅ Multi-agent tasks execute without immediate exit code 1 failures
- ✅ Agent output files (output.json, output.md, status.json) are created
- ✅ Error notifications send successfully when tasks fail
- ✅ No "unexpected keyword argument 'db_session'" errors in logs
- ✅ Tags are properly formatted as comma-separated strings
- ✅ All frontend builds and lints pass
- ✅ No console errors or Python syntax errors

## Architecture Notes

### `--dangerously-skip-permissions` Flag Usage

**Why this flag:**
- Multi-agent tasks run unattended (scheduled or triggered via API)
- User has already authorized task execution when creating the task
- Cannot have interactive permission prompts in automated execution
- AI workspace is sandboxed in `ai-workspace/` directory for safety

**Security considerations:**
- Tasks are created by authenticated users
- Workspace isolation provides safety boundary
- Alternative flags considered:
  - `--print`: Would change output format (breaks parsing)
  - `--allowedTools`: Would require maintaining whitelist (brittle)
  - `--yes`: Doesn't exist (was the bug)

### Notification Error Handling Pattern

**Previous (broken) pattern:**
```python
send_notification(
    title="Task Failed",
    message=str(e),
    db_session=db  # ❌ Function doesn't accept this
)
```

**Fixed pattern:**
```python
send_notification(
    title="Task Failed",
    message=str(e),
    tags="task,error"  # ✅ String format, no db_session
)
```

**Design decision:** `send_notification()` is a thin wrapper around the ntfy.sh HTTP API. Database logging is handled separately in the `ActivityLog` table by the executor, not by the notification function itself. This separation of concerns keeps the notification layer simple and focused.

### Tags Format

**ntfy.sh API expects:**
- Comma-separated string: `"warning,ai,task"`
- Sent as HTTP header: `X-Tags: warning,ai,task`

**Python list would cause:**
- Type error when constructing headers
- `TypeError: unsupported operand type(s) for +: 'str' and 'list'`

## Files Changed

**2 files modified:**
- `backend/claude_interface.py`: 3 lines changed (8 insertions, 3 deletions)
- `backend/executor.py`: 5 locations modified (10 insertions, 10 deletions)

**Total: 8 insertions(+), 13 deletions(-)**

### Critical Changes

**backend/claude_interface.py:**
- Line 8: Updated module docstring
- Line 64: Updated comment explaining flag usage
- Line 67: **CRITICAL** - Changed `'--yes'` to `'--dangerously-skip-permissions'`

**backend/executor.py:**
- Lines 142-143: Multi-agent completion notification (removed `db_session`, fixed `tags`)
- Lines 195-196: Multi-agent error notification (removed `db_session`, fixed `tags`)
- Lines 372-373: Standard task completion notification (removed `db_session`, fixed `tags`)
- Lines 431-432: Task timeout notification (removed `db_session`, fixed `tags`)
- Lines 494-495: Task error notification (removed `db_session`, fixed `tags`)

## Dependencies

**No new dependencies added.**

All changes use existing packages and APIs.

## Breaking Changes

**None.**

These are bug fixes that restore intended functionality. No API changes, no schema changes, no breaking behavior changes.

## Related Context

### Why These Bugs Weren't Caught Earlier

1. **Issue #197 (`--yes` flag):**
   - Integration tests likely mock the Claude Code subprocess
   - Flag validation only happens when actually spawning `claude` binary
   - Was introduced when multi-agent feature was first implemented
   - PR #196 fixed a separate issue (stdin → CLI argument) but this flag bug pre-existed

2. **Issue #198 (`db_session` argument):**
   - Error notification code path only executes when tasks fail
   - Happy path tests wouldn't trigger this code
   - Type checking doesn't catch dynamic kwargs errors in Python

3. **Tags type mismatch:**
   - Would have been caught on first notification send attempt
   - Discovered during code review by subagent while fixing Issue #198

### Test Coverage Gaps Identified

**Should add:**
- Integration test that actually spawns `claude --help` to validate flags
- Error path tests that verify notification sending works during failures
- Type checking for notification parameters

## Verification Checklist

Before merging, verify:

- [ ] Backend Python syntax check passes
- [ ] Frontend build succeeds with no errors
- [ ] Frontend lint passes
- [ ] Multi-agent task can spawn Claude Code subprocess (no immediate exit code 1)
- [ ] Agent output files are created in workspace
- [ ] Error notifications send successfully when tasks fail
- [ ] No "unexpected keyword argument" errors in logs
- [ ] Tags are formatted as comma-separated strings
- [ ] All manual testing scenarios pass

## Closes

Closes #197
Closes #198
