### PR TITLE
feat: add custom-research template with dynamic agent pipeline

### DIFF
--- a/ai-workspace/templates/custom-research.json
+++ b/ai-workspace/templates/custom-research.json
@@ -1,0 +1,76 @@
+{
+  "id": "custom-research",
+  "name": "Custom Research",
+  "description": "Research any topic across configurable sources (news, papers, repos, blogs, social) and deliver a formatted HTML email report.",
+  "command": "claude",
+  "default_schedule": null,
+  "default_priority": "default",
+  "parameters": {
+    "topic": {
+      "type": "string",
+      "description": "Topic to research (e.g., 'prompt engineering', 'Rust async runtimes')",
+      "required": true
+    },
+    "sources": {
+      "type": "string",
+      "description": "Comma-separated source types: news, papers, repos, blogs, social",
+      "required": false,
+      "default": "news,papers,repos,blogs,social"
+    },
+    "recipient_email": {
+      "type": "string",
+      "description": "Email address to receive the report",
+      "required": false,
+      "default": "thelawrencemoore@gmail.com"
+    },
+    "max_items_per_source": {
+      "type": "integer",
+      "description": "Maximum number of items per source section",
+      "required": false,
+      "default": 5
+    }
+  },
+  "email_report": {
+    "enabled": true,
+    "recipient_email": "{recipient_email}",
+    "formatter_agent": "formatter"
+  },
+  "dynamic_agents": {
+    "source_param": "sources",
+    "agent_prefix": "research_",
+    "suffix_agents": ["evaluator", "formatter"],
+    "synthesize": false,
+    "source_agents": {
+      "news": {
+        "type": "research",
+        "instructions": "Search for the latest news articles about: {topic}\n\nFocus on:\n- Breaking news and major announcements from the past 7 days\n- Coverage from reputable news sites (TechCrunch, Wired, Ars Technica, Reuters, etc.)\n- Industry developments, product launches, company news related to this topic\n\nFor each item provide:\n- title: Clear headline\n- url: Real verifiable URL\n- source: Publication name\n- summary: 2-3 sentence summary\n- date: Publication date\n- relevance: Score 1-10\n\nSave to output.json:\n{\"items\": [...], \"search_queries_used\": [...], \"sources_checked\": []}\n\nLimit to {max_items_per_source} most relevant items."
+      },
+      "papers": {
+        "type": "research",
+        "instructions": "Search for academic papers and research about: {topic}\n\nFocus on:\n- Recent arxiv preprints (cs.*, stat.*, q-bio.* categories as relevant)\n- Papers from major conferences (NeurIPS, ICML, ICLR, ACL, CVPR, etc.)\n- Highly cited foundational papers if topic is broad\n- Papers gaining attention on social media or in blogs\n\nSearch arxiv, Semantic Scholar, Papers With Code, Google Scholar.\n\nFor each item provide:\n- title: Paper title\n- url: arxiv URL or paper page (must be real)\n- authors: First author et al.\n- summary: 2-3 sentence plain-language summary of contribution\n- venue: Conference/journal or 'preprint'\n- relevance: Score 1-10\n\nSave to output.json:\n{\"items\": [...], \"search_queries_used\": [...], \"sources_checked\": []}\n\nLimit to {max_items_per_source} most relevant items."
+      },
+      "repos": {
+        "type": "research",
+        "instructions": "Search for notable open-source repositories and tools related to: {topic}\n\nFocus on:\n- Trending GitHub repos in this area\n- New releases of relevant libraries or frameworks\n- Interesting tools or utilities practitioners would use\n- Notable forks or derivatives\n\nSearch GitHub Trending, Hacker News, GitHub search.\n\nFor each item provide:\n- title: Repository or project name\n- url: GitHub URL (must be real)\n- description: What it does in 2-3 sentences\n- stars: Star count if available\n- language: Primary programming language\n- relevance: Score 1-10\n\nSave to output.json:\n{\"items\": [...], \"search_queries_used\": [...], \"sources_checked\": []}\n\nLimit to {max_items_per_source} most relevant items."
+      },
+      "blogs": {
+        "type": "research",
+        "instructions": "Search for high-quality blog posts and long-form articles about: {topic}\n\nFocus on:\n- Technical deep-dives and tutorials\n- Posts from practitioners, researchers, and engineers\n- Company engineering blogs (Google AI, OpenAI, Meta AI, Hugging Face, etc.)\n- Community platforms (Medium, Substack, dev.to, personal blogs)\n- Content from the past 30-60 days\n\nFor each item provide:\n- title: Article title\n- url: Real URL\n- author: Author name or organization\n- summary: 2-3 sentence description of key takeaways\n- date: Publication date\n- relevance: Score 1-10\n\nSave to output.json:\n{\"items\": [...], \"search_queries_used\": [...], \"sources_checked\": []}\n\nLimit to {max_items_per_source} most relevant items."
+      },
+      "social": {
+        "type": "research",
+        "instructions": "Search for notable social media discussions and community conversations about: {topic}\n\nFocus on:\n- High-engagement Twitter/X threads from domain experts\n- Top Hacker News discussions (show HN, Ask HN, news threads)\n- Reddit posts from relevant subreddits (r/MachineLearning, r/programming, r/LocalLLaMA, etc.)\n- LinkedIn posts from thought leaders\n- Discord/Slack announcements from major communities (if publicly accessible)\n\nFor each item provide:\n- title: Brief description of the discussion\n- url: Direct URL to post/thread\n- platform: Twitter/X, Hacker News, Reddit, etc.\n- summary: 2-3 sentence summary of key points or consensus\n- engagement: Likes/upvotes/comments if available\n- relevance: Score 1-10\n\nSave to output.json:\n{\"items\": [...], \"search_queries_used\": [...], \"sources_checked\": []}\n\nLimit to {max_items_per_source} most relevant items."
+      }
+    },
+    "suffix_roles": {
+      "evaluator": {
+        "type": "custom",
+        "instructions": "You are a research quality evaluator. Read all research agent outputs from the shared context file at ../shared/context.json.\n\nYour job is to:\n1. **Validate links**: For each URL, check it looks like a real URL from a known domain. Flag suspicious URLs with confidence: 'low'.\n2. **Deduplicate**: Remove items that cover the same story/paper/repo across different research agents. Keep the best version.\n3. **Rank by relevance**: Re-rank items within each source by relevance score and recency.\n4. **Quality check**: Flag items with generic or potentially hallucinated content as confidence: 'low'.\n5. **Add editorial notes**: For the top 3 items overall across all sources, add a 'why_notable' field.\n\nSave to output.json:\n{\n  \"<source_name>\": {\"items\": [...], \"removed_count\": 0},\n  ...\n  \"quality_report\": {\n    \"total_items_received\": 0,\n    \"duplicates_removed\": 0,\n    \"low_confidence_flagged\": 0,\n    \"items_after_evaluation\": 0\n  }\n}\n\nMark each item with: confidence: 'high' or 'medium' or 'low'\nThe source keys in output.json must match the agent names without the 'research_' prefix (e.g., agent 'research_news' -> key 'news')."
+      },
+      "formatter": {
+        "type": "custom",
+        "instructions": "You are an email formatter. Read the evaluator output from the shared context file at ../shared/context.json.\n\nGenerate a clean, professional HTML email report for the research topic: {topic}\n\nDesign requirements:\n- Clean, modern email-safe HTML (inline CSS only, no external stylesheets)\n- Mobile-responsive (max-width: 600px, centered)\n- Color scheme: dark header (#1a1a2e), white body, accent colors per source type\n- Source type colors: news (#3b82f6 blue), papers (#8b5cf6 purple), repos (#10b981 green), blogs (#f59e0b amber), social (#ec4899 pink)\n- For unknown source types, use (#6b7280 gray)\n- Each item: title as a clickable link, source/author, summary\n- Show confidence badge (yellow for 'medium', red for 'low') only for non-high confidence items\n- Include 'why_notable' callout box for editorially highlighted items\n- Quality report summary at the bottom\n- Header with topic name, date, and total item count\n- Footer with 'Generated by AI Assistant' note\n\nAlso generate a plain text version.\n\nSave to output.json with this EXACT structure:\n{\n  \"subject\": \"Research Report: {topic} - YYYY-MM-DD\",\n  \"html\": \"<html>complete email HTML here</html>\",\n  \"text\": \"Plain text version here\",\n  \"item_count\": 0,\n  \"sections\": [\"news\", \"papers\", ...]\n}\n\nIMPORTANT: html and text fields must be COMPLETE email content, no placeholders."
+      }
+    }
+  }
+}

--- a/backend/chat_context.py
+++ b/backend/chat_context.py
@@ -153,10 +153,17 @@ Templates provide rich, pre-built prompts for common workflows. ALWAYS prefer cr
 
 - **"dev-fix"** — Fix GitHub issues, work on backlogs, auto-fix bugs. Parameters: repo (required), issues, filter, max_issues, branch_prefix.
 - **"ai-news"** — Daily AI news research and email reports. Parameters: recipient_email (required), topics, max_items_per_topic.
+- **"custom-research"** — Research ANY topic across configurable sources and send an HTML email report. Parameters: topic (required), sources (optional, default: news,papers,repos,blogs,social), recipient_email (optional, default: thelawrencemoore@gmail.com), max_items_per_source (optional, default: 5).
+  - Valid sources: news, papers, repos, blogs, social (comma-separated)
+  - Use this when the user asks to "research X", "look into X", "find out about X and email me", etc.
+  - To run IMMEDIATELY (one-time, not scheduled): create with a specific one-time cron for a time a few minutes in the future, then immediately call execute_task.
 
 Examples:
 - "schedule a dev fix on my-org/my-repo for 9am weekdays" → POST /api/tasks/from-template with template_id="dev-fix", schedule="0 9 * * 1-5", parameters={{"repo": "my-org/my-repo"}}
 - "fix issues 42 and 57 at 3pm today" → POST /api/tasks/from-template with template_id="dev-fix", schedule="0 15 {today_day} {today_month} *", parameters={{"repo": "my-org/my-repo", "issues": "42,57"}}
+- "research prompt engineering and email me" → create_task_from_template with template_id="custom-research", schedule="0 9 {today_day} {today_month} *", parameters={{"topic": "prompt engineering"}}, then immediately execute_task
+- "research quantum computing papers only" → same but parameters={{"topic": "quantum computing", "sources": "papers"}}
+- "every Monday research AI safety news and blogs" → schedule="0 9 * * 1", parameters={{"topic": "AI safety", "sources": "news,blogs"}}
 
 ## Guidelines
 

--- a/backend/tests/test_custom_research_template.py
+++ b/backend/tests/test_custom_research_template.py
@@ -1,0 +1,300 @@
+"""Tests for custom-research dynamic_agents template support."""
+
+import json
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from task_tools import create_task_from_template, _load_template, TEMPLATES_DIR
+
+
+@pytest.fixture
+def temp_templates_dir(monkeypatch):
+    tmpdir = tempfile.mkdtemp()
+    from pathlib import Path
+    monkeypatch.setattr("task_tools.TEMPLATES_DIR", Path(tmpdir))
+    yield tmpdir
+    shutil.rmtree(tmpdir)
+
+
+@pytest.fixture
+def dynamic_template():
+    return {
+        "id": "dynamic-test",
+        "name": "Dynamic Test",
+        "description": "A template with dynamic_agents.",
+        "command": "claude",
+        "default_schedule": "0 9 * * *",
+        "default_priority": "default",
+        "parameters": {
+            "topic": {"type": "string", "description": "Topic", "required": True},
+            "sources": {
+                "type": "string",
+                "description": "Comma-separated sources",
+                "required": False,
+                "default": "news,papers",
+            },
+            "max_items_per_source": {
+                "type": "integer",
+                "description": "Max items",
+                "required": False,
+                "default": 5,
+            },
+        },
+        "email_report": {
+            "enabled": True,
+            "recipient_email": "test@example.com",
+            "formatter_agent": "formatter",
+        },
+        "dynamic_agents": {
+            "source_param": "sources",
+            "agent_prefix": "research_",
+            "suffix_agents": ["evaluator", "formatter"],
+            "synthesize": False,
+            "source_agents": {
+                "news": {
+                    "type": "research",
+                    "instructions": "Search news about {topic}. Max {max_items_per_source} items.",
+                },
+                "papers": {
+                    "type": "research",
+                    "instructions": "Find papers about {topic}. Max {max_items_per_source} items.",
+                },
+                "repos": {
+                    "type": "research",
+                    "instructions": "Find repos for {topic}. Max {max_items_per_source} items.",
+                },
+            },
+            "suffix_roles": {
+                "evaluator": {"type": "custom", "instructions": "Evaluate results for {topic}."},
+                "formatter": {"type": "custom", "instructions": "Format report for {topic}."},
+            },
+        },
+    }
+
+
+def _write_template(directory, template_dict):
+    path = os.path.join(directory, f"{template_dict['id']}.json")
+    with open(path, "w") as f:
+        json.dump(template_dict, f)
+    return path
+
+
+# --- Template structure tests ---
+
+
+def test_custom_research_template_exists():
+    """The custom-research.json template file exists and loads."""
+    tmpl = _load_template("custom-research")
+    assert tmpl["id"] == "custom-research"
+    assert "dynamic_agents" in tmpl
+    assert "parameters" in tmpl
+    assert tmpl["parameters"]["topic"]["required"] is True
+
+
+def test_custom_research_template_has_all_sources():
+    """Template defines agents for all 5 source types."""
+    tmpl = _load_template("custom-research")
+    source_agents = tmpl["dynamic_agents"]["source_agents"]
+    for source in ("news", "papers", "repos", "blogs", "social"):
+        assert source in source_agents, f"Missing source agent: {source}"
+
+
+def test_custom_research_template_has_suffix_roles():
+    """Template has evaluator and formatter suffix roles."""
+    tmpl = _load_template("custom-research")
+    suffix_roles = tmpl["dynamic_agents"]["suffix_roles"]
+    assert "evaluator" in suffix_roles
+    assert "formatter" in suffix_roles
+
+
+# --- Dynamic sequence building tests ---
+
+
+@pytest.mark.asyncio
+async def test_dynamic_agents_builds_correct_sequence(temp_templates_dir, dynamic_template):
+    """create_task_from_template builds correct sequence from sources parameter."""
+    _write_template(temp_templates_dir, dynamic_template)
+
+    from database import SessionLocal
+    from models import Task
+    db = SessionLocal()
+
+    try:
+        from sqlalchemy import text
+        user_exists = db.execute(text("SELECT COUNT(*) FROM User")).scalar()
+        if not user_exists:
+            pytest.skip("No test user in database")
+
+        result = await create_task_from_template(db, {
+            "template_id": "dynamic-test",
+            "name": "Dynamic Sequence Test",
+            "schedule": "0 9 * * *",
+            "parameters": {"topic": "quantum computing", "sources": "news,repos"},
+        })
+
+        assert "Success" in result
+
+        task = db.query(Task).filter_by(name="Dynamic Sequence Test").first()
+        assert task is not None
+
+        meta = task.task_metadata
+        agents = meta["agents"]
+
+        # Sequence: research_news, research_repos, evaluator, formatter
+        assert agents["sequence"] == ["research_news", "research_repos", "evaluator", "formatter"]
+
+        # Roles: only the selected sources + suffix
+        assert "research_news" in agents["roles"]
+        assert "research_repos" in agents["roles"]
+        assert "evaluator" in agents["roles"]
+        assert "formatter" in agents["roles"]
+        # Papers not requested -> not in roles
+        assert "research_papers" not in agents["roles"]
+
+    finally:
+        db.query(Task).filter_by(name="Dynamic Sequence Test").delete()
+        db.commit()
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_agents_substitutes_params_in_instructions(temp_templates_dir, dynamic_template):
+    """Parameters are substituted in dynamically built agent instructions."""
+    _write_template(temp_templates_dir, dynamic_template)
+
+    from database import SessionLocal
+    from models import Task
+    db = SessionLocal()
+
+    try:
+        from sqlalchemy import text
+        user_exists = db.execute(text("SELECT COUNT(*) FROM User")).scalar()
+        if not user_exists:
+            pytest.skip("No test user in database")
+
+        result = await create_task_from_template(db, {
+            "template_id": "dynamic-test",
+            "name": "Dynamic Substitution Test",
+            "schedule": "0 9 * * *",
+            "parameters": {
+                "topic": "Rust async",
+                "sources": "papers",
+                "max_items_per_source": 10,
+            },
+        })
+
+        assert "Success" in result
+
+        task = db.query(Task).filter_by(name="Dynamic Substitution Test").first()
+        meta = task.task_metadata
+        agents = meta["agents"]
+
+        papers_instructions = agents["roles"]["research_papers"]["instructions"]
+        assert "Rust async" in papers_instructions
+        assert "{topic}" not in papers_instructions
+        assert "10" in papers_instructions
+        assert "{max_items_per_source}" not in papers_instructions
+
+        formatter_instructions = agents["roles"]["formatter"]["instructions"]
+        assert "Rust async" in formatter_instructions
+        assert "{topic}" not in formatter_instructions
+
+    finally:
+        db.query(Task).filter_by(name="Dynamic Substitution Test").delete()
+        db.commit()
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_agents_invalid_source_returns_error(temp_templates_dir, dynamic_template):
+    """All-invalid sources in sources parameter returns error."""
+    _write_template(temp_templates_dir, dynamic_template)
+
+    result = await create_task_from_template(None, {
+        "template_id": "dynamic-test",
+        "parameters": {"topic": "AI", "sources": "invalid_source,another_bad"},
+    })
+
+    assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_dynamic_agents_uses_default_sources(temp_templates_dir, dynamic_template):
+    """When sources not provided, uses default from template."""
+    _write_template(temp_templates_dir, dynamic_template)
+
+    from database import SessionLocal
+    from models import Task
+    db = SessionLocal()
+
+    try:
+        from sqlalchemy import text
+        user_exists = db.execute(text("SELECT COUNT(*) FROM User")).scalar()
+        if not user_exists:
+            pytest.skip("No test user in database")
+
+        result = await create_task_from_template(db, {
+            "template_id": "dynamic-test",
+            "name": "Dynamic Default Sources Test",
+            "schedule": "0 9 * * *",
+            "parameters": {"topic": "AI safety"},
+            # sources not provided -> defaults to "news,papers"
+        })
+
+        assert "Success" in result
+
+        task = db.query(Task).filter_by(name="Dynamic Default Sources Test").first()
+        meta = task.task_metadata
+        agents = meta["agents"]
+
+        # Default sources in fixture are "news,papers"
+        assert "research_news" in agents["roles"]
+        assert "research_papers" in agents["roles"]
+        assert "research_repos" not in agents["roles"]
+
+    finally:
+        db.query(Task).filter_by(name="Dynamic Default Sources Test").delete()
+        db.commit()
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_agents_skips_unknown_sources_in_mixed_list(temp_templates_dir, dynamic_template):
+    """Unknown source types in a mixed sources list are skipped (valid ones proceed)."""
+    _write_template(temp_templates_dir, dynamic_template)
+
+    from database import SessionLocal
+    from models import Task
+    db = SessionLocal()
+
+    try:
+        from sqlalchemy import text
+        user_exists = db.execute(text("SELECT COUNT(*) FROM User")).scalar()
+        if not user_exists:
+            pytest.skip("No test user in database")
+
+        result = await create_task_from_template(db, {
+            "template_id": "dynamic-test",
+            "name": "Dynamic Mixed Sources Test",
+            "schedule": "0 9 * * *",
+            "parameters": {"topic": "AI", "sources": "news,unknown_source"},
+        })
+
+        assert "Success" in result
+
+        task = db.query(Task).filter_by(name="Dynamic Mixed Sources Test").first()
+        meta = task.task_metadata
+        agents = meta["agents"]
+
+        # Only 'news' is valid; unknown_source is silently skipped
+        assert "research_news" in agents["roles"]
+        assert "research_unknown_source" not in agents["roles"]
+        assert "research_news" in agents["sequence"]
+
+    finally:
+        db.query(Task).filter_by(name="Dynamic Mixed Sources Test").delete()
+        db.commit()
+        db.close()


### PR DESCRIPTION
## Summary
- Adds `ai-workspace/templates/custom-research.json` — a new template for researching any topic across configurable source types (news, papers, repos, blogs, social)
- Adds `dynamic_agents` support to `create_task_from_template` in `task_tools.py` — builds agent sequence and roles dynamically from a `sources` parameter
- Updates chat system prompt to teach the assistant about the custom-research template with usage examples
- Adds 8 tests covering template structure and dynamic agent pipeline behavior

## How it works
When the user says "research X and email me" in chat, the assistant calls `create_task_from_template` with `template_id="custom-research"` and `parameters={"topic": "X"}`. The backend dynamically constructs a multi-agent pipeline with one research agent per source type (news, papers, repos, blogs, social), plus a shared evaluator and formatter that generates an HTML email report.

## Test plan
- [x] `pytest backend/tests/test_custom_research_template.py -v` — 4/8 pass, 4 skip (no DB in worktree)
- [x] No regressions in full test suite
- [ ] Chat: "research prompt engineering and email me" creates task and triggers execution
- [ ] Email received at thelawrencemoore@gmail.com with formatted HTML report

🤖 Generated with [Claude Code](https://claude.com/claude-code)